### PR TITLE
Add webpack-analyzer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build --stats",
+    "analyze": "webpack-bundle-analyzer build/bundle-stats.json",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -35,8 +36,9 @@
   },
   "devDependencies": {
     "@types/node": "^16.11.21",
-    "@types/react-dom": "^17.0.11",
     "@types/react": "^17.0.38",
-    "@types/three": "^0.137.0"
+    "@types/react-dom": "^17.0.11",
+    "@types/three": "^0.137.0",
+    "webpack-bundle-analyzer": "^4.5.0"
   }
 }


### PR DESCRIPTION
Add a webpack-analyzer for local development.

Just run:
```
npm run build
npm run analyze
```

to get a nice view on bundle sizes.